### PR TITLE
OpenCV calibration bugfixes

### DIFF
--- a/ILCC/LM_opt.py
+++ b/ILCC/LM_opt.py
@@ -292,10 +292,10 @@ def opt_r_t(corners_in_img_arr, corners_in_pcd_arr, initial_guess=np.zeros(6).to
     return res
 
 
-def cal_ext_paras(ind_ls = (np.arange(1, 21)).tolist()):
+def cal_ext_paras(ind_ls = (np.arange(1, params['num_poses']+1)).tolist()):
     #ind_ls: Indexes of pairs used for optimization
 	
-	ls=ind_ls
+    ls = ind_ls
     # res_ls = []
     # pnp_ls = []
 

--- a/ILCC/config.py
+++ b/ILCC/config.py
@@ -24,7 +24,7 @@ def get_img_format(base_dir):
     file_ls = os.listdir(os.path.join(base_dir, "img"))
     for file in file_ls:
         ext = file.split(".")[-1]
-        if ext in ["png", "jpg"]:
+        if ext in ["png", "PNG", "jpg", "JPG"]:
             return ext
 
 # print default_params()

--- a/ILCC/img_corners_est.py
+++ b/ILCC/img_corners_est.py
@@ -83,13 +83,13 @@ def get_corner_coords(imagefilename, backend=params['backend'], size=make_tuple(
 def detect_img_corners():
     ls = np.arange(1,params['num_poses']+1).tolist()
     # ls = [20]
-    img_corner_path = os.path.join(base_dir, "output/img_corners/")
+    img_corner_path = os.path.join(params['base_dir'], "output/img_corners/")
     if os.path.isdir(img_corner_path):
         shutil.rmtree(img_corner_path)
     os.makedirs(img_corner_path)
     for i in ls:
         try:
-            imagefilename = os.path.join(base_dir,
+            imagefilename = os.path.join(params['base_dir'],
                                          "img", str(i).zfill(params['file_name_digits']) + "." + params['image_format'])
             print imagefilename
             corner_points = get_corner_coords(imagefilename)

--- a/ILCC/img_corners_est.py
+++ b/ILCC/img_corners_est.py
@@ -81,7 +81,7 @@ def get_corner_coords(imagefilename, backend=params['backend'], size=make_tuple(
 
 #
 def detect_img_corners():
-    ls = np.arange(1, 21).tolist()
+    ls = np.arange(1,params['num_poses']+1).tolist()
     # ls = [20]
     img_corner_path = os.path.join(base_dir, "output/img_corners/")
     if os.path.isdir(img_corner_path):

--- a/ILCC/img_corners_est.py
+++ b/ILCC/img_corners_est.py
@@ -53,11 +53,15 @@ def get_corner_coords(imagefilename, backend=params['backend'], size=make_tuple(
     elif backend == "opencv":
         print "OpenCV " + str(cv2.__version__) + " is used as backend for detecting corners"
         img = cv2.imread(imagefilename)
+        size=(size[0]-1,size[1]-1)
         print img.shape
 
         ret, corners = cv2.findChessboardCorners(img, size,
                                                  flags=cv2.CALIB_CB_ADAPTIVE_THRESH + cv2.CALIB_CB_NORMALIZE_IMAGE + cv2.CALIB_CB_FAST_CHECK)
         #flags=cv2.cv.CV_CALIB_CB_ADAPTIVE_THRESH + cv2.cv.CV_CALIB_CB_NORMALIZE_IMAGE + cv2.CALIB_CB_FAST_CHECK
+        corners_reshaped=corners.reshape((size[1],size[0],2))
+        corners_reshaped=np.flip(corners_reshaped,1)
+        corners=corners_reshaped.reshape((size[0]*size[1],1,2))
         if not ret:
             print "Corners can not be detected!"
             return None
@@ -97,7 +101,7 @@ def detect_img_corners():
             # print corner_points
             save_points_filename = img_corner_path + str(i).zfill(
                 params['file_name_digits']) + "_img_corners" + ".txt"
-            np.savetxt(save_points_filename, corner_points, delimiter=",")
+            np.savetxt(save_points_filename, np.squeeze(corner_points), delimiter=",")
         except:
             continue
 

--- a/config.yaml
+++ b/config.yaml
@@ -32,3 +32,4 @@
 ######### Settings for multi-processing
 'multi_proc': True #Use multiple processing
 'proc_num': 4 #The number of cores to use for multiple procesisng
+'num_poses': 20 #The number of images and laserscans 


### PR DESCRIPTION
This pull request makes calibration work using OpenCV instead of matlab.
List of changes:
- Removed hardcoding of (image,scan) pair number, and added proper config file parameter for the purpose
- Allowing more image formats (JPG, PNG)
- bugfix to search for the proper base_dir from config file.
- Fixed ordering in the opencv calibration case, when looking for the pattern in the image. Also Matlab expects the number of patches in the pattern, and OpenCV expects the number of inner corners, so this offset was added.